### PR TITLE
Include NeoBundle first time setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mv ~/Downloads/vimrc ~/.vimrc
 ```
 * Execute ViM and it will install plugins automatically
 ```
-vim +qall
+vim +NeoBundleInstall +qall
 ```
 
 ## Updating to the latest version


### PR DESCRIPTION
If NeoBundle is not installed, then is necessary to run `vim +NeoBundleInstall +qall`. As `+NeoBundleInstall` has no side effect, even if already installed, this instruction on README.md may be interesting as default.
