### PR TITLE
add the i flag to guioptions for gtk graphical vim

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -123,7 +123,7 @@ colorscheme molokai
 set mousemodel=popup
 set t_Co=256
 set nocursorline
-set guioptions=egmrt
+set guioptions=egmrti
 set gfn=Monospace\ 8
 
 if has("gui_running")


### PR DESCRIPTION
Without the i option gnome 3 classic doesn't show the vim icon for gvim, but instead shows a generic and much smaller image. This change seems to work fine with macvim on Mavericks as well.
