### PR TITLE
Check for existence of functions before declaring

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -222,19 +222,19 @@ nnoremap <silent> <leader>sh :VimShellCreate<CR>
 "" Functions
 "*****************************************************************************
 if !exists('*s:setupWrapping')
-	function s:setupWrapping()
-	  set wrap
-	  set wm=2
-	  set textwidth=79
-	endfunction
+  function s:setupWrapping()
+    set wrap
+    set wm=2
+    set textwidth=79
+  endfunction
 endif
 
 if !exists('*TrimWhiteSpace')
-	function TrimWhiteSpace()
-	  let @*=line(".")
-	  %s/\s*$//e
-	  ''
-	endfunction
+  function TrimWhiteSpace()
+    let @*=line(".")
+    %s/\s*$//e
+    ''
+  endfunction
 endif
 
 "*****************************************************************************


### PR DESCRIPTION
This is good for when we try to reload .vimrc using `:so $MYVIMRC`
