### PR TITLE
Improves copy/paste to clipboard

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -319,6 +319,10 @@ let g:airline_enable_syntastic = 1
 nnoremap <silent> <leader>S :call TrimWhiteSpace()<cr>:let @/=''<CR>
 
 "" Copy/Paste/Cut
+if has('unnamedplus')
+  set clipboard=unnamed,unnamedplus
+endif
+
 noremap YY "+y<CR>
 noremap P "+gP<CR>
 noremap XX "+x<CR>


### PR DESCRIPTION
Hi there,

I made some changes following this vimcasts tip:
http://vimcasts.org/episodes/accessing-the-system-clipboard-from-vim/

Now we don't have to use `:set paste` or `:set nopaste`, just use `YY` and `P` for copy/paste to any clipboard system. 
