### PR TITLE
Disable scrolloff for Neovim Terminal mode

### DIFF
--- a/vim_template/vimrc
+++ b/vim_template/vimrc
@@ -180,7 +180,12 @@ endif
 
 "" Disable the blinking cursor.
 set gcr=a:blinkon0
+{{if .Editor "nvim"}}
+au TermEnter * setlocal scrolloff=0
+au TermLeave * setlocal scrolloff=3
+{{else}}
 set scrolloff=3
+{{end}}
 
 "" Status bar
 set laststatus=2


### PR DESCRIPTION
`scrolloff` causes unexpected scrolling behaviour in terminal mode.
`scrolloff=3` can be kept on for everything else.
See https://github.com/neovim/neovim/issues/11072

Vim8 doesn't have this behaviour so only needs to be set for nvim.