### PR TITLE
Add tag to vim-ruby-refactoring in ruby.bundle template

### DIFF
--- a/vim_template/langs/ruby/ruby.bundle
+++ b/vim_template/langs/ruby/ruby.bundle
@@ -2,4 +2,4 @@ Plug 'tpope/vim-rails'
 Plug 'tpope/vim-rake'
 Plug 'tpope/vim-projectionist'
 Plug 'thoughtbot/vim-rspec'
-Plug 'ecomba/vim-ruby-refactoring'
+Plug 'ecomba/vim-ruby-refactoring', {'tag': 'main'}


### PR DESCRIPTION
Problem: failure to pull plugin `vim-ruby-refactoring` when execute PlugInstall for generated vimrc to use with ruby language.
The Github repository of `ecomba/vim-ruby-refactoring` has changed its default branch from `master` to `main`. This change add tag to the plugin so it will pull the `main` branch instead of the default `master`.
