### PR TITLE
Update deprecated command

### DIFF
--- a/generate/vim_template/vimrc
+++ b/generate/vim_template/vimrc
@@ -315,7 +315,7 @@ noremap <Leader>v :<C-u>vsplit<CR>
 
 "" Git
 noremap <Leader>ga :Gwrite<CR>
-noremap <Leader>gc :Gcommit<CR>
+noremap <Leader>gc :Git commit --verbose<CR>
 noremap <Leader>gsh :Gpush<CR>
 noremap <Leader>gll :Gpull<CR>
 noremap <Leader>gs :Gstatus<CR>


### PR DESCRIPTION
Gcommit is deprecated in favor of Git commit

At least, this is the message that appears when I type <Leader>gc in NeoVim. Using **:Git commit** directly seems to work without any issues and the **--verbose** flag makes the commit easier to write because it shows the difference on the bottom of the message, however this flag is totally optional.