### PR TITLE
Update deprecated commands

### DIFF
--- a/generate/vim_template/langs/php/php.vim
+++ b/generate/vim_template/langs/php/php.vim
@@ -7,9 +7,9 @@ nmap <Leader>mm :call phpactor#ContextMenu()<CR>
 nmap <Leader>nn :call phpactor#Navigate()<CR>
 " Goto definition of class or class member under the cursor
 nmap <Leader>oo :call phpactor#GotoDefinition()<CR>
-nmap <Leader>oh :call phpactor#GotoDefinitionHsplit()<CR>
-nmap <Leader>ov :call phpactor#GotoDefinitionVsplit()<CR>
-nmap <Leader>ot :call phpactor#GotoDefinitionTab()<CR>
+nmap <Leader>oh :call phpactor#GotoDefinition('hsplit')<CR>
+nmap <Leader>ov :call phpactor#GotoDefinition('vsplit')<CR>
+nmap <Leader>ot :call phpactor#GotoDefinition('tabnew')<CR>
 " Show brief information about the symbol under the cursor
 nmap <Leader>K :call phpactor#Hover()<CR>
 " Transform the classes in the current file


### PR DESCRIPTION
Update some deprecated commands from phpactor which are not working anymore, from what I can see the other commands seem to be working.

I searched the documentation to see the alternatives and it seems that these ones do the job appropriately.

`:help phpactor`
_phpactor-commands_ section

