### PR TITLE
Update ocaml template to work with latest version of opam

### DIFF
--- a/generate/vim_template/langs/ocaml/ocaml.vim
+++ b/generate/vim_template/langs/ocaml/ocaml.vim
@@ -1,5 +1,5 @@
 " Add Merlin to rtp
-let g:opamshare = substitute(system('opam config var share'),'\n$','','''')
+let g:opamshare = substitute(system('opam var share'),'\n$','','''')
 execute "set rtp+=" . g:opamshare . "/merlin/vim"
 
 " ale


### PR DESCRIPTION
In the latest version of the opam CLI (2.1.0, released in August), `opam config var share` was deprecated, being replaced with `opam var share`. This commit should fix an issue that would appear on vim start if the ocaml language was enabled.
