### PR TITLE
Top bar text not visible on mobile devices

### DIFF
--- a/template/assets/css/style.css
+++ b/template/assets/css/style.css
@@ -37,6 +37,7 @@
 
 #topbar a {
     text-decoration: none;
+    font-size: 13px;
 }
 
 .Discount_ppp__1reUC {


### PR DESCRIPTION
Added `font-size: 13px;` at L40 of [style.css](https://github.com/editor-bootstrap/vim-bootstrap/blob/main/template/assets/css/style.css), to make the text visible both on mobile and laptop/PC.

Fixes #393 

