### PR TITLE
Fix wrong ctags package name for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ sudo pacman -S git ctags ncurses curl
 * Fedora
 
 ```
-$ sudo dnf install ncurses-devel git ctags-etags curl
+$ sudo dnf install ncurses-devel git ctags curl
 ```
 
 * openSUSE


### PR DESCRIPTION
Since Fedora 35 `ctags-etags` package has been replaced by `ctags`, see:
https://fedora.pkgs.org/35/fedora-x86_64/ctags-5.9-1.20210725.0.fc35.x86_64.rpm.html