### PR TITLE
fix: use value of `nvim` instead of `neovim`

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -182,8 +182,8 @@
                     <div class="drac-box Highlights_card__34b3J">
                         <div class="drac-box Highlights_cardBackground__2Fr7t drac-bg-purple-cyan">
                             <div class="drac-box Highlights_cardDetailsContainer__8lpMI drac-rounded-xl">
-                                <img class="logo-icon selected" data-name="editor" data-type="radio" data-value="neovim" alt="Click to select editor neovim" src="/assets/images/logo/neovim.png" />
-                                <input type="radio" name="editor" value="neovim" class="hidden" checked="checked">
+                                <img class="logo-icon selected" data-name="editor" data-type="radio" data-value="nvim" alt="Click to select editor neovim" src="/assets/images/logo/neovim.png" />
+                                <input type="radio" name="editor" value="nvim" class="hidden" checked="checked">
                             </div>
                         </div>
                         <div class="drac-box drac-p-md">


### PR DESCRIPTION
### Steps to Reproduce:
- download a `generate.vim` from https://vim-bootstrap.com/ after choosing "neovim" and "go"
- open vim

### Symptoms and Debugging:

<img width="543" alt="Screen Shot 2022-01-26 at 6 57 23 PM" src="https://user-images.githubusercontent.com/6201488/151271992-cf44b94b-5285-4736-b0b5-88bf4421e0c7.png">


[Google results](https://github.com/editor-bootstrap/vim-bootstrap/issues/178): 


<img width="240" alt="Screen Shot 2022-01-26 at 6 58 39 PM" src="https://user-images.githubusercontent.com/6201488/151272141-5d032bec-8808-4d77-9e68-d73168a0e5da.png">


At this point I'm thinking "Ooookaaay, so why am I still getting vim settings even though I chose neovim"


Reason: The vimrc template [checks for `nvim`](https://github.com/editor-bootstrap/vim-bootstrap/blob/main/generate/vim_template/vimrc#L174):


<img width="263" alt="Screen Shot 2022-01-26 at 7 07 11 PM" src="https://user-images.githubusercontent.com/6201488/151272896-603a09d8-2472-4240-89e8-809baf60424b.png">


...but `index.html`s `value` for editor [is `neovim`](https://github.com/editor-bootstrap/vim-bootstrap/blob/main/template/index.html#L186)


<img width="653" alt="Screen Shot 2022-01-26 at 7 09 04 PM" src="https://user-images.githubusercontent.com/6201488/151273120-7dcce26b-0472-4ff8-9d49-78e119c425b4.png">

### Solution:
- use `nvim` in the html template, not `neovim`. This is what the value was before https://github.com/editor-bootstrap/vim-bootstrap/pull/381


