### PR TITLE
Fix invalid indentLine_concealcursor value type breaking VIM 8.2 (#406)

### DIFF
--- a/generate/vim_template/vimrc
+++ b/generate/vim_template/vimrc
@@ -167,7 +167,7 @@ else
 
   " IndentLine
   let g:indentLine_enabled = 1
-  let g:indentLine_concealcursor = 0
+  let g:indentLine_concealcursor = ''
   let g:indentLine_char = '┆'
   let g:indentLine_faster = 1
 


### PR DESCRIPTION
The value type for `g:indentLine_concealcursor` is currently wrong (it should be a `string`, not a `number`), causing the `indentLine` plugin to throw an error starting with VIM 8.2, possibly because type checking became stricter in that version of VIM?

This fixes it by changing the value from `0` to `''`.