### PR TITLE
Add labels to languages and frameworks

### DIFF
--- a/template/assets/css/style.css
+++ b/template/assets/css/style.css
@@ -571,7 +571,7 @@
 
 .Highlights_cardBackground__2Fr7t {
     width: 100%;
-    height: 200px;
+    height: 220px;
     border-top-left-radius: 1rem;
     border-top-right-radius: 1rem;
     display: flex;
@@ -587,7 +587,7 @@
 .Highlights_cardDetails__v4Cip,
 .Highlights_cardDetailsContainer__8lpMI {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
 }

--- a/template/assets/css/style.css
+++ b/template/assets/css/style.css
@@ -869,4 +869,5 @@
     -webkit-column-count: 4;
     column-count: 4;
     display: grid;
+    text-align: center;
 }

--- a/template/index.html
+++ b/template/index.html
@@ -114,6 +114,9 @@
                             <div class="drac-box Highlights_cardBackground__2Fr7t">
                                 <div class="drac-box Highlights_cardDetailsContainer__8lpMI drac-rounded-xl">
                                     <img class="logo-icon" data-type="checkbox" data-value="{{$lang}}" alt="image for language {{$lang}}" title="Click to select programming language {{$lang}}" src="/assets/images/logo/{{$lang}}.png" />
+                                    <div class="drac-box drac-mt-sm">
+                                        <span class="drac-text drac-line-height-lg drac-text-white drac-mt-sm">{{$lang}}</span>
+                                      </div>
                                     <input type="checkbox" name="langs" value="{{$lang}}" class="hidden">
                                 </div>
                             </div>
@@ -136,6 +139,9 @@
                             <div class="drac-box Highlights_cardBackground__2Fr7t">
                                 <div class="drac-box Highlights_cardDetailsContainer__8lpMI drac-rounded-xl">
                                     <img class="logo-icon" data-type="checkbox" data-value="{{$framework}}" alt="Click to select framework {{$framework}}" src="/assets/images/logo/{{$framework}}.png" />
+                                    <div class="drac-box drac-mt-sm">
+                                        <span class="drac-text drac-line-height-lg drac-text-white drac-mt-sm">{{$framework}}</span>
+                                      </div>
                                     <input type="checkbox" name="frameworks" value="{{$framework}}" class="hidden">
                                 </div>
                             </div>


### PR DESCRIPTION
Hey, while browsing https://vim-bootstrap.com/, I was struggling mentally to match the languages/frameworks icons with their name. I thought it would be nice to add them, as it's done for the themes below.

Here's are my changes:
- Add labels to langs & frameworks
- Align center themes labels

Let me know if I can do something else :)

---
# Design diff

## Languages
**Before**
![Screenshot 2022-07-22 at 12-55-48 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425410-47d55860-2cf1-4d76-9d0c-ae8d34602028.png)

**After**
![Screenshot 2022-07-22 at 12-58-17 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425545-8144d1e3-015e-45a4-847e-141b2f724fb3.png)

## Frameworks
**Before**
![Screenshot 2022-07-22 at 12-55-59 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425427-a44986de-b104-4df0-9b0f-cbaf5d004af0.png)

**After**
![Screenshot 2022-07-22 at 12-57-07 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425461-693a8a90-0ef7-4b45-b8a5-37ea4927fa10.png)

## Themes
**Before**
![Screenshot 2022-07-22 at 12-56-16 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425441-925e827e-51c7-4fe2-88dd-de5994f05dc5.png)

**After**
![Screenshot 2022-07-22 at 12-57-10 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425468-7e1ace31-c18b-4889-8589-3ebf66413ddc.png)

## Full website
<details>
  <summary><b>Before</b> (open ⤵️)</summary>

![Screenshot 2022-07-22 at 12-59-00 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425759-56ce041c-6d62-4f2e-8796-87ed68d232ba.png)

</details>

<details>
  <summary><b>After</b> (open ⤵️)</summary>

![Screenshot 2022-07-22 at 12-59-13 Vim Bootstrap](https://user-images.githubusercontent.com/2109178/180425769-58cbb19a-ab8b-43fb-a4a8-36cc52f194a3.png)  

</details>