### PR TITLE
fix: horizontal overflow

### DIFF
--- a/template/assets/css/style.css
+++ b/template/assets/css/style.css
@@ -571,6 +571,8 @@
     justify-content: space-around;
     max-width: 82em;
     margin: 0 auto;
+    overflow-x: scroll;
+    scrollbar-width: none;
 }
 
 .Highlights_card__34b3J {


### PR DESCRIPTION
This PR fixes the overflow caused by theme selector, as mentioned in the issue #418 

## Description
Introduced a scroll bar to overcome the overflow.

**Screenshot**
![fixed](https://user-images.githubusercontent.com/64256342/195971515-7f715d15-596c-4973-8dbe-94b60398d750.png)

