### PR TITLE
Add new theme onedark

### DIFF
--- a/generate/vim_template/themes/onedark/onedark.bundle
+++ b/generate/vim_template/themes/onedark/onedark.bundle
@@ -1,0 +1,1 @@
+Plug 'joshdick/onedark.vim'

--- a/generate/vim_template/themes/onedark/onedark.vim
+++ b/generate/vim_template/themes/onedark/onedark.vim
@@ -1,0 +1,1 @@
+colorscheme onedark


### PR DESCRIPTION
One Dark theme originated from the Atom text editor. This uses [onedark.vim](https://github.com/joshdick/onedark.vim) for the theme.