### PR TITLE
Add material theme

### DIFF
--- a/generate/vim_template/themes/material/material.bundle
+++ b/generate/vim_template/themes/material/material.bundle
@@ -1,0 +1,1 @@
+Plug 'kaicataldo/material.vim'

--- a/generate/vim_template/themes/material/material.vim
+++ b/generate/vim_template/themes/material/material.vim
@@ -1,0 +1,1 @@
+colorscheme material


### PR DESCRIPTION
Add the [material theme](https://github.com/kaicataldo/material.vim) to vim-bootstrap, following the [README guidelines for adding a new theme](https://github.com/editor-bootstrap/vim-bootstrap#adding-a-new-theme) and previous PRs like [this one](https://github.com/editor-bootstrap/vim-bootstrap/pull/425). Tested locally with `./vim-bootstrap -langs=go -editor=vim -theme=material > ~/.vimrc`

