### PR TITLE
Add the option of choosing the solarized theme when selecting the theme

### DIFF
--- a/generate/vim_template/themes/solarized/solarized.bundle
+++ b/generate/vim_template/themes/solarized/solarized.bundle
@@ -1,0 +1,1 @@
+Plug 'altercation/vim-colors-solarized'

--- a/generate/vim_template/themes/solarized/solarized.vim 
+++ b/generate/vim_template/themes/solarized/solarized.vim 
@@ -1,0 +1,1 @@
+colorscheme solarized


### PR DESCRIPTION
This PR adds the possibility to select the `solarized` theme when choosing the theme to install as part of the generated `.vimrc` file.