### PR TITLE
Fixes removed `:Gbrowse` command - Issue #431

### DIFF
--- a/generate/vim_template/vimrc
+++ b/generate/vim_template/vimrc
@@ -48,7 +48,7 @@ Plug 'majutsushi/tagbar'
 Plug 'dense-analysis/ale'
 Plug 'Yggdroot/indentLine'
 Plug 'editor-bootstrap/vim-bootstrap-updater'
-Plug 'tpope/vim-rhubarb' " required by fugitive to :Gbrowse
+Plug 'tpope/vim-rhubarb' " required by fugitive to :GBrowse
 {{.BufferTheme.Bundle}}
 
 if isdirectory('/usr/local/opt/fzf')
@@ -434,7 +434,7 @@ vnoremap J :m '>+1<CR>gv=gv
 vnoremap K :m '<-2<CR>gv=gv
 
 "" Open current line on GitHub
-nnoremap <Leader>o :.Gbrowse<CR>
+nnoremap <Leader>o :.GBrowse<CR>
 
 "*****************************************************************************
 "" Custom configs


### PR DESCRIPTION
This PR targets issue #431. 
The old command `:Gbrowse` is replaced by the new one `:GBrowse`