### PR TITLE
fix: fixing height of cards

### DIFF
--- a/template/assets/css/style.css
+++ b/template/assets/css/style.css
@@ -580,6 +580,7 @@
     border-radius: var(--rounded-2xl);
     background: #1d1e26;
     margin: 0 15px 40px;
+    height: calc(100% - 40px);
 }
 
 .Highlights_cardBackground__2Fr7t {


### PR DESCRIPTION
This PR fixes the height of the cards, as mentioned in the issue #417 

**Description**
Added CSS styling to card to fix the height of the cards

**Screenshot**
![Screenshot 2023-09-28 at 7 52 59 PM](https://github.com/editor-bootstrap/vim-bootstrap/assets/29957300/26bd994c-5e46-4d5c-848d-de2eb09e5c34)

